### PR TITLE
Feature/split images

### DIFF
--- a/docker/Dockerfile-dev-server
+++ b/docker/Dockerfile-dev-server
@@ -1,0 +1,8 @@
+FROM matthewpatell/universal-docker-server:3.7
+
+# TODO: write script which will generate gourp of dockerfiles with same version
+
+RUN apt-get install -y \
+    php7.1-dev \
+    php7.1-phpdbg php7.1-xdebug \
+    php-codesniffer

--- a/docker/Dockerfile-php-fpm
+++ b/docker/Dockerfile-php-fpm
@@ -27,7 +27,7 @@ RUN apt-get update -y --fix-missing \
             php7.1-sybase php7.1-tidy \
             php7.1-xml php7.1-xmlrpc php7.1-xsl \
             php7.1-zip php7.1-bz2 \
-            php7.1-dev php7.1-phpdbg php7.1-xdebug \
+            php7.1-dev \
     # Pecl extensions
     # yaml
     && apt-get install -y libyaml-dev \
@@ -35,7 +35,7 @@ RUN apt-get update -y --fix-missing \
     && echo "extension=yaml.so" >> /etc/php/7.1/mods-available/yaml.ini \
     && phpenmod yaml \
     # Cleaup
-    && apt-get remove -y gnupg \
+    && apt-get remove -y php7.1-dev gnupg \
     && apt-get -y autoremove && apt-get autoclean
 
 EXPOSE 9000

--- a/docker/Dockerfile-server
+++ b/docker/Dockerfile-server
@@ -1,4 +1,4 @@
-FROM matthewpatell/universal-docker-php-fpm:3.6
+FROM matthewpatell/universal-docker-php-fpm:3.7
 
 # Utils
 RUN apt-get update -y --fix-missing \

--- a/docker/scripts/get-certificates.sh
+++ b/docker/scripts/get-certificates.sh
@@ -13,8 +13,8 @@ set +a
 CERTIFICATE_WEB_ROOT="${PACKAGE_DOCKER_FOLDER_CONTAINER}/nginx/web"
 
 for i in ${!SSL_DOMAINS[*]}; do
-    EMAIL="$(cut -d':' -f1 <<<"$SSL_DOMAINS[$i]")"
-    LIST_DOMAINS="$(cut -d':' -f2 <<<"$SSL_DOMAINS[$i]")"
+    EMAIL="$(cut -d':' -f1 <<<"${SSL_DOMAINS[$i]}")"
+    LIST_DOMAINS="$(cut -d':' -f2 <<<"${SSL_DOMAINS[$i]}")"
 
     COMMAND="certbot certonly --webroot --agree-tos --no-eff-email --email $EMAIL -w $CERTIFICATE_WEB_ROOT"
 


### PR DESCRIPTION
Remove debug and build tools from `php-fpm` image (reduces size by 45%). And create new one for debug and code quality tools.

- Use `php-fpm` and `server` for production/ci instances.
- Use `dev-server` for development.

