### PR TITLE
tune nginx cache settings

### DIFF
--- a/conf/nginx-proxy.conf
+++ b/conf/nginx-proxy.conf
@@ -4,15 +4,14 @@ server {
     server_name $DOMAINS;
 
     location / {
-        proxy_pass                 http://$CONTAINER_IP$PORT;
-        proxy_pass_request_headers on;
-        proxy_redirect             off;
-        proxy_set_header           Host $host;
-        proxy_set_header           X-Real-IP $remote_addr;
-        proxy_set_header           X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header           X-Forwarded-Host $server_name;
-        proxy_set_header           Upgrade $http_upgrade;
-        proxy_set_header           Connection "Upgrade";
-        proxy_cache                origin;
+        proxy_pass       http://$CONTAINER_IP$PORT;
+        proxy_redirect   off;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host $server_name;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
+        proxy_cache      origin;
     }
 }

--- a/conf/nginx-proxy.conf
+++ b/conf/nginx-proxy.conf
@@ -4,11 +4,15 @@ server {
     server_name $DOMAINS;
 
     location / {
-        proxy_pass         http://$CONTAINER_IP$PORT;
-        proxy_redirect     off;
-        proxy_set_header   Host $host;
-        proxy_set_header   X-Real-IP $remote_addr;
-        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header   X-Forwarded-Host $server_name;
+        proxy_pass                 http://$CONTAINER_IP$PORT;
+        proxy_pass_request_headers on;
+        proxy_redirect             off;
+        proxy_set_header           Host $host;
+        proxy_set_header           X-Real-IP $remote_addr;
+        proxy_set_header           X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header           X-Forwarded-Host $server_name;
+        proxy_set_header           Upgrade $http_upgrade;
+        proxy_set_header           Connection "Upgrade";
+        proxy_cache                origin;
     }
 }

--- a/docker/nginx/snippets/static.conf
+++ b/docker/nginx/snippets/static.conf
@@ -7,12 +7,15 @@ location ~ ^/assets/.*\.php$ {
 # prevent nginx from serving dotfiles (.htaccess, .svn, .git, etc.)
 location ~ /\. {
     deny all;
-    access_log off;
     log_not_found off;
+    access_log off;
 }
 
-# Tell browser to cache files, do not log missing file. NOTE: CACHE - ONLY PRODUCTION ENVIRONMENT
-location ~* \.(js|css|woff2|woff|ttf|eot)$ {
+# Tell browser to cache static files, do not log missing file.
+# NOTE: CACHE - ONLY PRODUCTION ENVIRONMENT
+
+# Scripts and styles
+location ~* \.(js|css)$ {
     if ($PROJECT_ENVIRONMENT = PROD) {
         expires 7d;
         add_header Cache-Control "max-age=604800";
@@ -20,10 +23,22 @@ location ~* \.(js|css|woff2|woff|ttf|eot)$ {
 
     try_files $uri =404;
     log_not_found off;
+    access_log off;
+}
+
+# Fonts - cache forever
+location ~* \.(woff2|woff|ttf|eot)$ {
+    if ($PROJECT_ENVIRONMENT = PROD) {
+        expires max;
+        add_header Cache-Control "public";
+    }
+
+    try_files $uri =404;
+    log_not_found off;
+    access_log off;
 }
 
 # TODO: if image not found - try default image.
-# Tell browser to cache files, do not log missing file. NOTE: CACHE - ONLY PRODUCTION ENVIRONMENT
 location ~* \.(svg|swf|ico|pdf|mov|fla|zip|rar)$ {
     if ($PROJECT_ENVIRONMENT = PROD) {
         expires 30d;
@@ -48,7 +63,6 @@ location ~* "^(?<path>.+)\.(png|jpg|jpeg|gif)$" {
     log_not_found off;
     access_log off;
 }
-
 
 # Disable logging for favicon
 location ~* favicon.ico$ {


### PR DESCRIPTION
1. Add infinite cache for fonts (google page speed recommendation)
1. Allow proxying headers from internal (containered) nginx through proxy